### PR TITLE
Merge latest upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: go
+
+go:
+  - 1.4
+  - 1.3
+
+install:
+  - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+
+script:
+  - go test -cover ./...
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 
 install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+  - go get github.com/jessevdk/go-flags
 
 script:
   - go get

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: go
 
 go:
-  - 1.4
-  - 1.3
+  - 1.8
+  - 1.7
 
 install:
   - if ! go get code.google.com/p/go.tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
 
 script:
+  - go get
   - go test -cover ./...
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Provides the abiilty to modify and test a JSON according to a
 
 *Version*: **1.0**
 
+[![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
+
+[![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=RFC7386)](https://travis-ci.org/evanphx/json-patch)
 
 ### API Usage
 

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ $ go run main.go
 
 ## Run It!
 ### CLI for comparing JSON documents
-You can install the commandline program `json-patch` which can take multiple 
-JSON patch documents, and be feed a JSON document from `stdin`. It will 
-apply the patch(es) against the document and output the modified doc.
+You can install the commandline program `json-patch`.
+
+This program can take multiple JSON patch documents as arguments, 
+and fed a JSON document from `stdin`. It will apply the patch(es) against 
+the document and output the modified doc.
 
 **patch.1.json**
 ```json

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # JSON-Patch
 `jsonpatch` is a library which provides functionallity for both applying
-[RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against JSON
-documents, as well as for calculating & applying
-[RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396).
+[RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against documents, as
+well as for calculating & applying [RFC7396 JSON merge patches](https://tools.ietf.org/html/rfc7396).
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JSON-Patch
-`jsonpatch` provides the ability to parse and apply
-[RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against JSON documents.
-It allows for generating and applying
-[RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396) as well.
+`jsonpatch` is a library which provides functionallity for both applying
+[RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against JSON
+documents, as well as for calculating & applying
+[RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396).
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,46 @@ Provides the ability to modify and test a JSON according to a
 *Version*: **1.0**
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
-
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
+[![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
 ### API Usage
+#### Create a merge patch
+Given both an original JSON document and a modified JSON document, you can create
+a "merge patch" document, used to describe the changes needed to convert from the
+original to the modified.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+	modified := []byte(`{"name": "Jane", "age": 24}`)
+
+	patch, err := jsonpatch.CreateMergePatch(original, modified)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(string(patch))
+}
+```
+
+When ran, you get the following output:
+
+```bash
+$ go run main.go
+{"height":null,"name":"Jane"}
+```
+
+#### Decode a Patch
+
 
 * Given a `[]byte`, obtain a Patch object
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,21 @@ as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc73
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 [![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
+* [Get It!](#get-it)
+* [Use It!](#use-it)
+* [Help It!](#help-it)
+
 ## Get It!
 
-**Latest and greatest**: `go get -u github.com/evanphx/json-patch`
+**Latest and greatest**: 
+```bash
+go get -u github.com/evanphx/json-patch
+```
 
 **Stable Versions**:
 * Version 3: `go get -u gopkg.in/evanphx/json-patch.v3`
 
-(previous versions unavailable)
+(previous versions below `v3` are unavailable)
 
 ## Use It!
 * [Create a merge patch](#create-a-merge-patch)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ $ go run main.go
 {"age":24,"name":"Jane"}
 ```
 
-## Comparing JSON documents
+## Run It!
+### CLI for comparing JSON documents
 You can install the commandline program `json-patch` which can take multiple 
 JSON patch documents, and be feed a JSON document from `stdin`. It will 
 apply the patch(es) against the document and output the modified doc.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## JSON-Patch
 
 Provides the abiilty to modify and test a JSON according to a
-[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [JSON Merge Patch](http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07).
+[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7386 JSON Merge Patch](https://tools.ietf.org/html/rfc7386).
 
 *Version*: **1.0**
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc73
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 [![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
-* [Get It!](#get-it)
-* [Use It!](#use-it)
-* [Help It!](#help-it)
-
 ## Get It!
 
 **Latest and greatest**: 
@@ -145,3 +141,7 @@ $ go install github.com/evanphx/json-patch/cmd/json-patch
 $ cat document.json | json-patch -p patch.1.json -p patch.2.json
 {"address":"123 Main St","age":"21","name":"Jane"}
 ```
+
+## Help It!
+Contributions are welcomed! Leave [an issue](https://github.com/evanphx/json-patch/issues)
+or [create a PR](https://github.com/evanphx/json-patch/compare)!

--- a/README.md
+++ b/README.md
@@ -121,10 +121,6 @@ Modified document: {"age":24,"name":"Jane"}
 ```
 
 ## Comparing JSON documents
-One cannot simply directly compare two JSON strings or byte arrays to determine
-if they are the same. This is because while they may have the same structure,
-whitespace and ordering differences can cause 
-
 Due to potential whitespace and ordering differences, one cannot simply compare
 JSON strings or byte-arrays directly. 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Provides the abiilty to modify and test a JSON according to a
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
 
-[![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=RFC7386)](https://travis-ci.org/evanphx/json-patch)
+[![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 
 ### API Usage
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,18 @@ as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc73
 
 ## Get It!
 
-Latest and greatest: `go get -u github.com/evanphx/json-patch`
+**Latest and greatest**: `go get -u github.com/evanphx/json-patch`
 
-Stable Versions:
+**Stable Versions**:
 * Version 3: `go get -u gopkg.in/evanphx/json-patch.v3`
+
 (previous versions unavailable)
 
 ## Use It!
+* [Create a merge patch](#create-a-merge-patch)
+* [Create and apply a Patch](#create-and-apply-a-patch)
+* [Comparing JSON documents](#comparing-json-documents)
+
 ### Create a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a "merge patch" document, used to describe the changes needed to convert from the

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ $ cat document.json | json-patch -p patch.1.json -p patch.2.json
 
 # Help It!
 Contributions are welcomed! Leave [an issue](https://github.com/evanphx/json-patch/issues)
-or [create a PR](https://github.com/evanphx/json-patch/compare)!
+or [create a PR](https://github.com/evanphx/json-patch/compare).
+
+
+Before creating a pull request, we'd ask that you make sure tests are passing
+and that you have added new tests when applicable.
 
 Contributors can run tests using:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## JSON-Patch
+# JSON-Patch
 `jsonpatch` provides the ability to decode and apply JSON patches against
 documents, as well as generate merge-patches.
 
@@ -9,7 +9,7 @@ as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc73
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 [![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
-## Get It!
+# Get It!
 
 **Latest and greatest**: 
 ```bash
@@ -21,12 +21,12 @@ go get -u github.com/evanphx/json-patch
 
 (previous versions below `v3` are unavailable)
 
-## Use It!
+# Use It!
 * [Create a merge patch](#create-a-merge-patch)
 * [Create and apply a Patch](#create-and-apply-a-patch)
 * [Comparing JSON documents](#comparing-json-documents)
 
-### Create a merge patch
+## Create a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a "merge patch" document, used to describe the changes needed to convert from the
 original to the modified.
@@ -60,7 +60,7 @@ $ go run main.go
 {"height":null,"name":"Jane"}
 ```
 
-### Create and apply a Patch
+## Create and apply a Patch
 You can create patch objects using `DecodePatch([]byte)`, which can then 
 be applied against JSON documents.
 
@@ -104,7 +104,7 @@ $ go run main.go
 {"age":24,"name":"Jane"}
 ```
 
-### Comparing JSON documents
+## Comparing JSON documents
 You can install the commandline program `json-patch` which can take multiple 
 JSON patch documents, and be feed a JSON document from `stdin`. It will 
 apply the patch(es) against the document and output the modified doc.
@@ -142,7 +142,7 @@ $ cat document.json | json-patch -p patch.1.json -p patch.2.json
 {"address":"123 Main St","age":"21","name":"Jane"}
 ```
 
-## Help It!
+# Help It!
 Contributions are welcomed! Leave [an issue](https://github.com/evanphx/json-patch/issues)
 or [create a PR](https://github.com/evanphx/json-patch/compare)!
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ go get -u github.com/evanphx/json-patch
 
 ## Create and apply a merge patch
 Given both an original JSON document and a modified JSON document, you can create
-a [Merge Patche](https://tools.ietf.org/html/rfc7396) document. 
+a [Merge Patch](https://tools.ietf.org/html/rfc7396) document. 
 
 It can describe the changes needed to convert from the original to the 
 modified JSON document.

--- a/README.md
+++ b/README.md
@@ -22,14 +22,20 @@ go get -u github.com/evanphx/json-patch
 (previous versions below `v3` are unavailable)
 
 # Use It!
-* [Create a merge patch](#create-a-merge-patch)
-* [Create and apply a Patch](#create-and-apply-a-patch)
+* [Create and apply a merge patch](#create-and-apply-a-merge-patch)
+* [Create and apply a JSON Patch](#create-and-apply-a-json-patch)
 * [Comparing JSON documents](#comparing-json-documents)
+* [Combine merge patches](#combine-merge-patches)
 
-## Create a merge patch
+## Create and apply a merge patch
 Given both an original JSON document and a modified JSON document, you can create
-a "merge patch" document, used to describe the changes needed to convert from the
-original to the modified.
+a [Merge Patche](https://tools.ietf.org/html/rfc7396) document. 
+
+It can describe the changes needed to convert from the original to the 
+modified JSON document.
+
+Once you have a merge patch, you can apply it to other JSON documents using the
+`jsonpatch.MergePatch(document, patch)` function.
 
 ```go
 package main
@@ -41,15 +47,22 @@ import (
 )
 
 func main() {
+	// Let's create a merge patch from these two documents...
 	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
-	modified := []byte(`{"name": "Jane", "age": 24}`)
+	target := []byte(`{"name": "Jane", "age": 24}`)
 
-	patch, err := jsonpatch.CreateMergePatch(original, modified)
+	patch, err := jsonpatch.CreateMergePatch(original, target)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Println(string(patch))
+	// Now lets apply the patch against a different JSON document...
+
+	alternative := []byte(`{"name": "Tina", "age": 28, "height": 3.75}`)
+	modifiedAlternative, err := jsonpatch.MergePatch(alternative, patch)
+
+	fmt.Printf("patch document:   %s\n", patch)
+	fmt.Printf("updated alternative doc: %s\n", modifiedAlternative)
 }
 ```
 
@@ -57,10 +70,11 @@ When ran, you get the following output:
 
 ```bash
 $ go run main.go
-{"height":null,"name":"Jane"}
+patch document:   {"height":null,"name":"Jane"}
+updated tina doc: {"age":28,"name":"Jane"}
 ```
 
-## Create and apply a Patch
+## Create and apply a JSON Patch
 You can create patch objects using `DecodePatch([]byte)`, which can then 
 be applied against JSON documents.
 
@@ -77,7 +91,7 @@ import (
 )
 
 func main() {
-	document := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
 	patchJSON := []byte(`[
 		{"op": "replace", "path": "/name", "value": "Jane"},
 		{"op": "remove", "path": "/height"}
@@ -88,12 +102,13 @@ func main() {
 		panic(err)
 	}
 
-	modified, err := patch.Apply(document)
+	modified, err := patch.Apply(original)
 	if err != nil {
 		panic(err)
 	}
 
-	fmt.Println(string(modified))
+	fmt.Printf("Original document: %s\n", original)
+	fmt.Printf("Modified document: %s\n", modified)
 }
 ```
 
@@ -101,11 +116,124 @@ When ran, you get the following output:
 
 ```bash
 $ go run main.go
-{"age":24,"name":"Jane"}
+Original document: {"name": "John", "age": 24, "height": 3.21}
+Modified document: {"age":24,"name":"Jane"}
 ```
 
-## Run It!
-### CLI for comparing JSON documents
+## Comparing JSON documents
+One cannot simply directly compare two JSON strings or byte arrays to determine
+if they are the same. This is because while they may have the same structure,
+whitespace and ordering differences can cause 
+
+Due to potential whitespace and ordering differences, one cannot simply compare
+JSON strings or byte-arrays directly. 
+
+As such, you can instead use `jsonpatch.Equal(document1, document2)` to 
+determine if two JSON documents are _structurally_ equal. This ignores
+whitespace differences, and key-value ordering.
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	// Let's create a merge patch from these two documents...
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+	similar := []byte(`
+		{
+			"age": 24,
+			"height": 3.21,
+			"name": "John"
+		}
+	`)
+	different := []byte(`{"name": "Jane", "age": 20, "height": 3.37}`)
+
+	if jsonpatch.Equal(original, similar) {
+		fmt.Println(`"original" is structurally equal to "similar"`)
+	}
+
+	if !jsonpatch.Equal(original, different) {
+		fmt.Println(`"original" is _not_ structurally equal to "similar"`)
+	}
+}
+```
+
+When ran, you get the following output:
+```bash
+$ go run main.go
+"original" is structurally equal to "similar"
+"original" is _not_ structurally equal to "similar"
+```
+
+## Combine merge patches
+Given two JSON merge patch documents, it is possible to combine them into a 
+single merge patch which can describe both set of changes.
+
+The resulting merge patch can be used such that applying it results in a
+document structurally similar as merging each merge patch to the document
+in succession. 
+
+```go
+package main
+
+import (
+	"fmt"
+
+	jsonpatch "github.com/evanphx/json-patch"
+)
+
+func main() {
+	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
+
+	nameAndHeight := []byte(`{"height":null,"name":"Jane"}`)
+	ageAndEyes := []byte(`{"age":4.23,"eyes":"blue"}`)
+
+	// Let's combine these merge patch documents...
+	combinedPatch, err := jsonpatch.MergeMergePatches(nameAndHeight, ageAndEyes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Apply each patch individual against the original document
+	withoutCombinedPatch, err := jsonpatch.MergePatch(original, nameAndHeight)
+	if err != nil {
+		panic(err)
+	}
+
+	withoutCombinedPatch, err = jsonpatch.MergePatch(withoutCombinedPatch, ageAndEyes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Apply the combined patch against the original document
+
+	withCombinedPatch, err := jsonpatch.MergePatch(original, combinedPatch)
+	if err != nil {
+		panic(err)
+	}
+
+	// Do both result in the same thing? They should!
+	if jsonpatch.Equal(withCombinedPatch, withoutCombinedPatch) {
+		fmt.Println("Both JSON documents are structurally the same!")
+	}
+
+	fmt.Printf("combined merge patch: %s", combinedPatch)
+}
+```
+
+When ran, you get the following output:
+```bash
+$ go run main.go
+Both JSON documents are structurally the same!
+combined merge patch: {"age":4.23,"eyes":"blue","height":null,"name":"Jane"}
+```
+
+# CLI for comparing JSON documents
 You can install the commandline program `json-patch`.
 
 This program can take multiple JSON patch documents as arguments, 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # JSON-Patch
-`jsonpatch` provides the ability to decode and apply JSON patches against
-documents, as well as generate merge-patches.
-
-Specifically, this package provides the ability to apply [RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) 
-as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396).
+`jsonpatch` provides the ability to parse and apply
+[RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) against JSON documents.
+It allows for generating and applying
+[RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396) as well.
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## JSON-Patch
 
-Provides the ability to modify and test a JSON according to a
-[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7396 JSON Merge Patch](https://tools.ietf.org/html/rfc7396).
+This package provides the ability to apply [RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) 
+as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396).
 
 *Version*: **1.0**
 
@@ -9,8 +9,8 @@ Provides the ability to modify and test a JSON according to a
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 [![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
-### API Usage
-#### Create a merge patch
+## API Usage
+### Create a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a "merge patch" document, used to describe the changes needed to convert from the
 original to the modified.
@@ -44,7 +44,7 @@ $ go run main.go
 {"height":null,"name":"Jane"}
 ```
 
-#### Create and apply a Patch
+### Create and apply a Patch
 You can create patch objects using `DecodePatch([]byte)`, which can then 
 be applied against JSON documents.
 
@@ -88,43 +88,40 @@ $ go run main.go
 {"age":24,"name":"Jane"}
 ```
 
-#### Comparing JSON documents
+### Comparing JSON documents
+You can install the commandline program `json-patch` which can take multiple 
+JSON patch documents, and be feed a JSON document from `stdin`. It will 
+apply the patch(es) against the document and output the modified doc.
 
-If you have two JSON documents, you can  compare documents for structural
-equality using `Equal`, which will compare the two documents based on their
-actual keys and values, and not on whitespace or attribute ordering.
+**patch.1.json**
+```json
+[
+    {"op": "replace", "path": "/name", "value": "Jane"},
+    {"op": "remove", "path": "/height"}
+]
+```
 
-For example:
+**patch.2.json**
+```json
+[
+    {"op": "add", "path": "/address", "value": "123 Main St"},
+    {"op": "replace", "path": "/age", "value": "21"}
+]
+```
 
-```go
-package main
-
-import (
-	"fmt"
-
-	jsonpatch "github.com/evanphx/json-patch"
-)
-
-func main() {
-	firstDoc := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
-	secondDoc := []byte(`{
-		"height": 3.21,
-		"age"	: 24,
-		"name"	: "John"
-	}`)
-
-	didMatch := jsonpatch.Equal(firstDoc, secondDoc)
-	if didMatch {
-		fmt.Println("The two documents were the same structurally.")
-	} else {
-		fmt.Println("The two documents were structurally different.")
-	}
+**document.json**
+```json
+{
+    "name": "John",
+    "age": 24,
+    "height": 3.21
 }
 ```
 
-When ran, you get the following output:
+You can then run:
 
 ```bash
-$ go run main.go
-The two documents were structurally equal.
+$ go install github.com/evanphx/json-patch/cmd/json-patch
+$ cat document.json | json-patch -p patch.1.json -p patch.2.json
+{"address":"123 Main St","age":"21","name":"Jane"}
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
 ## JSON-Patch
+`jsonpatch` provides the ability to decode and apply JSON patches against
+documents, as well as generate merge-patches.
 
-This package provides the ability to apply [RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) 
+Specifically, this package provides the ability to apply [RFC6902 JSON patches](http://tools.ietf.org/html/rfc6902) 
 as well as create [RFC7396 JSON Merge Patches](https://tools.ietf.org/html/rfc7396).
-
-*Version*: **1.0**
 
 [![GoDoc](https://godoc.org/github.com/evanphx/json-patch?status.svg)](http://godoc.org/github.com/evanphx/json-patch)
 [![Build Status](https://travis-ci.org/evanphx/json-patch.svg?branch=master)](https://travis-ci.org/evanphx/json-patch)
 [![Report Card](https://goreportcard.com/badge/github.com/evanphx/json-patch)](https://goreportcard.com/report/github.com/evanphx/json-patch)
 
-## API Usage
+## Get It!
+
+Latest and greatest: `go get -u github.com/evanphx/json-patch`
+
+Stable Versions:
+* Version 3: `go get -u gopkg.in/evanphx/json-patch.v3`
+(previous versions unavailable)
+
+## Use It!
 ### Create a merge patch
 Given both an original JSON document and a modified JSON document, you can create
 a "merge patch" document, used to describe the changes needed to convert from the

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## JSON-Patch
 
-Provides the abiilty to modify and test a JSON according to a
+Provides the ability to modify and test a JSON according to a
 [RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7396 JSON Merge Patch](https://tools.ietf.org/html/rfc7396).
 
 *Version*: **1.0**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## JSON-Patch
 
 Provides the abiilty to modify and test a JSON according to a
-[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7386 JSON Merge Patch](https://tools.ietf.org/html/rfc7386).
+[RFC6902 JSON patch](http://tools.ietf.org/html/rfc6902) and [RFC7396 JSON Merge Patch](https://tools.ietf.org/html/rfc7396).
 
 *Version*: **1.0**
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ import (
 )
 
 func main() {
-	// Let's create a merge patch from these two documents...
 	original := []byte(`{"name": "John", "age": 24, "height": 3.21}`)
 	similar := []byte(`
 		{

--- a/README.md
+++ b/README.md
@@ -145,3 +145,12 @@ $ cat document.json | json-patch -p patch.1.json -p patch.2.json
 ## Help It!
 Contributions are welcomed! Leave [an issue](https://github.com/evanphx/json-patch/issues)
 or [create a PR](https://github.com/evanphx/json-patch/compare)!
+
+Contributors can run tests using:
+
+```bash
+go test -cover ./...
+```
+
+Builds for pull requests are tested automatically 
+using [TravisCI](https://travis-ci.org/evanphx/json-patch).

--- a/cmd/json-patch/file_flag.go
+++ b/cmd/json-patch/file_flag.go
@@ -1,0 +1,39 @@
+package main
+
+// Borrowed from Concourse: https://github.com/concourse/atc/blob/master/atccmd/file_flag.go
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FileFlag is a flag for passing a path to a file on disk. The file is
+// expected to be a file, not a directory, that actually exists.
+type FileFlag string
+
+// UnmarshalFlag implements go-flag's Unmarshaler interface
+func (f *FileFlag) UnmarshalFlag(value string) error {
+	stat, err := os.Stat(value)
+	if err != nil {
+		return err
+	}
+
+	if stat.IsDir() {
+		return fmt.Errorf("path '%s' is a directory, not a file", value)
+	}
+
+	abs, err := filepath.Abs(value)
+	if err != nil {
+		return err
+	}
+
+	*f = FileFlag(abs)
+
+	return nil
+}
+
+// Path is the path to the file
+func (f FileFlag) Path() string {
+	return string(f)
+}

--- a/cmd/json-patch/main.go
+++ b/cmd/json-patch/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	flags "github.com/jessevdk/go-flags"
+)
+
+type opts struct {
+	PatchFilePaths []FileFlag `long:"patch-file" short:"p" value-name:"PATH" description:"Path to file with one or more operations"`
+}
+
+func main() {
+	var o opts
+	_, err := flags.Parse(&o)
+	if err != nil {
+		log.Fatalf("error: %s\n", err)
+	}
+
+	patches := make([]jsonpatch.Patch, len(o.PatchFilePaths))
+
+	for i, patchFilePath := range o.PatchFilePaths {
+		var bs []byte
+		bs, err = ioutil.ReadFile(patchFilePath.Path())
+		if err != nil {
+			log.Fatalf("error reading patch file: %s", err)
+		}
+
+		var patch jsonpatch.Patch
+		patch, err = jsonpatch.DecodePatch(bs)
+		if err != nil {
+			log.Fatalf("error decoding patch file: %s", err)
+		}
+
+		patches[i] = patch
+	}
+
+	doc, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("error reading from stdin: %s", err)
+	}
+
+	mdoc := doc
+	for _, patch := range patches {
+		mdoc, err = patch.Apply(mdoc)
+		if err != nil {
+			log.Fatalf("error applying patch: %s", err)
+		}
+	}
+
+	fmt.Printf("%s", mdoc)
+}

--- a/merge.go
+++ b/merge.go
@@ -218,6 +218,9 @@ func matchesValue(av, bv interface{}) bool {
 			}
 		}
 		return true
+	case []interface{}:
+		bt := bv.([]interface{})
+		return matchesArray(at, bt)
 	}
 	return false
 }

--- a/merge.go
+++ b/merge.go
@@ -224,6 +224,9 @@ func matchesValue(av, bv interface{}) bool {
 		if bt == at {
 			return true
 		}
+	case nil:
+		// Both nil, fine.
+		return true
 	case map[string]interface{}:
 		bt := bv.(map[string]interface{})
 		for key := range at {

--- a/merge.go
+++ b/merge.go
@@ -162,6 +162,11 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	return json.Marshal(doc)
 }
 
+// resemblesJSONArray indicates whether the byte-slice "appears" to be
+// a JSON array or not.
+// False-positives are possible, as this function does not check the internal
+// structure of the array. It only checks that the outer syntax is present and
+// correct.
 func resemblesJSONArray(input []byte) bool {
 	input = bytes.TrimSpace(input)
 
@@ -171,9 +176,11 @@ func resemblesJSONArray(input []byte) bool {
 	return hasPrefix && hasSuffix
 }
 
-// CreateMergePatch will return a merge-patch document capable of converting
+// CreateMergePatch will return a merge patch document capable of converting
 // the original document(s) to the modified document(s).
-// The merge patch is as specified in http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
+// The parameters can be bytes of either two JSON Documents, or two arrays of
+// JSON documents.
+// The merge patch returned follows the specification defined at http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
 func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 	originalResemblesArray := resemblesJSONArray(originalJSON)
 	modifiedResemblesArray := resemblesJSONArray(modifiedJSON)

--- a/merge.go
+++ b/merge.go
@@ -230,16 +230,20 @@ func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 
 	res := []json.RawMessage{}
 
-	for _, original := range originalDocs {
-		for _, modified := range modifiedDocs {
-			patch, err := createObjectMergePatch(original, modified)
-			if err != nil {
-				return nil, err
-			}
+	total := len(originalDocs)
+	if len(modifiedDocs) != total {
+		return nil, errBadJSONDoc
+	}
 
-			// We get back bytes, but since we need to
-			res = append(res, json.RawMessage(patch))
+	for i := 0; i < len(originalDocs); i++ {
+		original := originalDocs[i]
+		modified := modifiedDocs[i]
+		patch, err := createObjectMergePatch(original, modified)
+		if err != nil {
+			return nil, err
 		}
+
+		res = append(res, json.RawMessage(patch))
 	}
 
 	return json.Marshal(res)

--- a/merge.go
+++ b/merge.go
@@ -26,14 +26,13 @@ func merge(cur, patch *lazyNode) *lazyNode {
 }
 
 func mergeDocs(doc, patch *partialDoc) {
-	pruneDocNulls(doc)
 	for k, v := range *patch {
 		if v == nil {
 			delete(*doc, k)
 		} else {
 			cur, ok := (*doc)[k]
 
-			if !ok {
+			if !ok || cur == nil {
 				pruneNulls(v)
 				(*doc)[k] = v
 			} else {

--- a/merge.go
+++ b/merge.go
@@ -28,7 +28,6 @@ func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
 
 func mergeDocs(doc, patch *partialDoc, mergeMerge bool) {
 	for k, v := range *patch {
-		k := decodePatchKey(k)
 		if v == nil {
 			if mergeMerge {
 				(*doc)[k] = nil
@@ -250,16 +249,15 @@ func matchesValue(av, bv interface{}) bool {
 func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
 	into := map[string]interface{}{}
 	for key, bv := range b {
-		escapedKey := encodePatchKey(key)
 		av, ok := a[key]
 		// value was added
 		if !ok {
-			into[escapedKey] = bv
+			into[key] = bv
 			continue
 		}
 		// If types have changed, replace completely
 		if reflect.TypeOf(av) != reflect.TypeOf(bv) {
-			into[escapedKey] = bv
+			into[key] = bv
 			continue
 		}
 		// Types are the same, compare values
@@ -272,23 +270,23 @@ func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
 				return nil, err
 			}
 			if len(dst) > 0 {
-				into[escapedKey] = dst
+				into[key] = dst
 			}
 		case string, float64, bool:
 			if !matchesValue(av, bv) {
-				into[escapedKey] = bv
+				into[key] = bv
 			}
 		case []interface{}:
 			bt := bv.([]interface{})
 			if !matchesArray(at, bt) {
-				into[escapedKey] = bv
+				into[key] = bv
 			}
 		case nil:
 			switch bv.(type) {
 			case nil:
 				// Both nil, fine.
 			default:
-				into[escapedKey] = bv
+				into[key] = bv
 			}
 		default:
 			panic(fmt.Sprintf("Unknown type:%T in key %s", av, key))

--- a/merge.go
+++ b/merge.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"strings"
 )
 
 func merge(cur, patch *lazyNode, mergeMerge bool) *lazyNode {
@@ -300,24 +299,4 @@ func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 	return into, nil
-}
-
-// From http://tools.ietf.org/html/rfc6901#section-4 :
-//
-// Evaluation of each reference token begins by decoding any escaped
-// character sequence.  This is performed by first transforming any
-// occurrence of the sequence '~1' to '/', and then transforming any
-// occurrence of the sequence '~0' to '~'.
-
-var (
-	rfc6901Encoder = strings.NewReplacer("~", "~0", "/", "~1")
-	rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
-)
-
-func decodePatchKey(k string) string {
-	return rfc6901Decoder.Replace(k)
-}
-
-func encodePatchKey(k string) string {
-	return rfc6901Encoder.Replace(k)
 }

--- a/merge.go
+++ b/merge.go
@@ -69,7 +69,7 @@ func pruneDocNulls(doc *partialDoc) *partialDoc {
 }
 
 func pruneAryNulls(ary *partialArray) *partialArray {
-	var newAry []*lazyNode
+	newAry := []*lazyNode{}
 
 	for _, v := range *ary {
 		if v != nil {

--- a/merge.go
+++ b/merge.go
@@ -26,6 +26,7 @@ func merge(cur, patch *lazyNode) *lazyNode {
 }
 
 func mergeDocs(doc, patch *partialDoc) {
+	pruneDocNulls(doc)
 	for k, v := range *patch {
 		if v == nil {
 			delete(*doc, k)

--- a/merge.go
+++ b/merge.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 func merge(cur, patch *lazyNode) *lazyNode {
@@ -27,6 +28,7 @@ func merge(cur, patch *lazyNode) *lazyNode {
 
 func mergeDocs(doc, patch *partialDoc) {
 	for k, v := range *patch {
+		k := decodePatchKey(k)
 		if v == nil {
 			delete(*doc, k)
 		} else {
@@ -229,15 +231,16 @@ func matchesValue(av, bv interface{}) bool {
 func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
 	into := map[string]interface{}{}
 	for key, bv := range b {
+		escapedKey := encodePatchKey(key)
 		av, ok := a[key]
 		// value was added
 		if !ok {
-			into[key] = bv
+			into[escapedKey] = bv
 			continue
 		}
 		// If types have changed, replace completely
 		if reflect.TypeOf(av) != reflect.TypeOf(bv) {
-			into[key] = bv
+			into[escapedKey] = bv
 			continue
 		}
 		// Types are the same, compare values
@@ -250,23 +253,23 @@ func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
 				return nil, err
 			}
 			if len(dst) > 0 {
-				into[key] = dst
+				into[escapedKey] = dst
 			}
 		case string, float64, bool:
 			if !matchesValue(av, bv) {
-				into[key] = bv
+				into[escapedKey] = bv
 			}
 		case []interface{}:
 			bt := bv.([]interface{})
 			if !matchesArray(at, bt) {
-				into[key] = bv
+				into[escapedKey] = bv
 			}
 		case nil:
 			switch bv.(type) {
 			case nil:
 				// Both nil, fine.
 			default:
-				into[key] = bv
+				into[escapedKey] = bv
 			}
 		default:
 			panic(fmt.Sprintf("Unknown type:%T in key %s", av, key))
@@ -280,4 +283,24 @@ func getDiff(a, b map[string]interface{}) (map[string]interface{}, error) {
 		}
 	}
 	return into, nil
+}
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+
+var (
+	rfc6901Encoder = strings.NewReplacer("~", "~0", "/", "~1")
+	rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+)
+
+func decodePatchKey(k string) string {
+	return rfc6901Decoder.Replace(k)
+}
+
+func encodePatchKey(k string) string {
+	return rfc6901Encoder.Replace(k)
 }

--- a/merge.go
+++ b/merge.go
@@ -1,6 +1,7 @@
 package jsonpatch
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -89,6 +90,7 @@ func pruneAryNulls(ary *partialArray) *partialArray {
 
 var errBadJSONDoc = fmt.Errorf("Invalid JSON Document")
 var errBadJSONPatch = fmt.Errorf("Invalid JSON Patch")
+var errBadMergeTypes = fmt.Errorf("Mismatched JSON Documents")
 
 // MergeMergePatches merges two merge patches together, such that
 // applying this resulting merged merge patch to a document yields the same
@@ -160,28 +162,87 @@ func doMergePatch(docData, patchData []byte, mergeMerge bool) ([]byte, error) {
 	return json.Marshal(doc)
 }
 
+func resemblesJSONArray(input []byte) bool {
+	input = bytes.TrimSpace(input)
+
+	hasPrefix := bytes.HasPrefix(input, []byte("["))
+	hasSuffix := bytes.HasSuffix(input, []byte("]"))
+
+	return hasPrefix && hasSuffix
+}
+
 // CreateMergePatch creates a merge patch as specified in http://tools.ietf.org/html/draft-ietf-appsawg-json-merge-patch-07
 //
 // 'a' is original, 'b' is the modified document. Both are to be given as json encoded content.
 // The function will return a mergeable json document with differences from a to b.
 //
 // An error will be returned if any of the two documents are invalid.
-func CreateMergePatch(a, b []byte) ([]byte, error) {
-	aI := map[string]interface{}{}
-	bI := map[string]interface{}{}
-	err := json.Unmarshal(a, &aI)
+func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalResemblesArray := resemblesJSONArray(originalJSON)
+	modifiedResemblesArray := resemblesJSONArray(modifiedJSON)
+
+	if originalResemblesArray && modifiedResemblesArray {
+		return createArrayMergePatch(originalJSON, modifiedJSON)
+	}
+
+	if !originalResemblesArray && !modifiedResemblesArray {
+		return createObjectMergePatch(originalJSON, modifiedJSON)
+	}
+
+	return nil, errBadMergeTypes
+}
+
+func createObjectMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDoc := map[string]interface{}{}
+	modifiedDoc := map[string]interface{}{}
+
+	err := json.Unmarshal(originalJSON, &originalDoc)
 	if err != nil {
 		return nil, errBadJSONDoc
 	}
-	err = json.Unmarshal(b, &bI)
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDoc)
 	if err != nil {
 		return nil, errBadJSONDoc
 	}
-	dest, err := getDiff(aI, bI)
+
+	dest, err := getDiff(originalDoc, modifiedDoc)
 	if err != nil {
 		return nil, err
 	}
+
 	return json.Marshal(dest)
+}
+
+func createArrayMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
+	originalDocs := []json.RawMessage{}
+	modifiedDocs := []json.RawMessage{}
+
+	err := json.Unmarshal(originalJSON, &originalDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	err = json.Unmarshal(modifiedJSON, &modifiedDocs)
+	if err != nil {
+		return nil, errBadJSONDoc
+	}
+
+	res := []json.RawMessage{}
+
+	for _, original := range originalDocs {
+		for _, modified := range modifiedDocs {
+			patch, err := createObjectMergePatch(original, modified)
+			if err != nil {
+				return nil, err
+			}
+
+			// We get back bytes, but since we need to
+			res = append(res, json.RawMessage(patch))
+		}
+	}
+
+	return json.Marshal(res)
 }
 
 // Returns true if the array matches (must be json types).

--- a/merge.go
+++ b/merge.go
@@ -185,14 +185,17 @@ func CreateMergePatch(originalJSON, modifiedJSON []byte) ([]byte, error) {
 	originalResemblesArray := resemblesJSONArray(originalJSON)
 	modifiedResemblesArray := resemblesJSONArray(modifiedJSON)
 
+	// Do both byte-slices seem like JSON arrays?
 	if originalResemblesArray && modifiedResemblesArray {
 		return createArrayMergePatch(originalJSON, modifiedJSON)
 	}
 
+	// Are both byte-slices are not arrays? Then they are likely JSON objects...
 	if !originalResemblesArray && !modifiedResemblesArray {
 		return createObjectMergePatch(originalJSON, modifiedJSON)
 	}
 
+	// None of the above? Then return an error because of mismatched types.
 	return nil, errBadMergeTypes
 }
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -271,6 +271,23 @@ func TestMergeEmptyArray(t *testing.T) {
 	}
 }
 
+func TestCreateMergePatchNil(t *testing.T) {
+	doc := `{ "title": "hello", "nested": {"one": 1, "two": [{"one":null}, {"two":null}, {"three":null}]} }`
+	pat := doc
+
+	exp := `{}`
+
+	res, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Object array was not added")
+	}
+}
+
 func TestMergeObjArray(t *testing.T) {
 	doc := `{ "array": [ {"a": {"b": 2}}, {"a": {"b": 3}} ]}`
 	exp := `{}`

--- a/merge_test.go
+++ b/merge_test.go
@@ -107,6 +107,23 @@ func TestMergePatchReturnsErrorOnBadJSON(t *testing.T) {
 	}
 }
 
+func TestMergePatchReturnsEmptyArrayOnEmptyArray(t *testing.T) {
+	doc := `{ "array": ["one", "two"] }`
+	pat := `{ "array": [] }`
+
+	exp := `{ "array": [] }`
+
+	res, err := MergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Emtpy array did not return not return as empty array")
+	}
+}
+
 var rfcTests = []struct {
 	target   string
 	patch    string

--- a/merge_test.go
+++ b/merge_test.go
@@ -39,6 +39,19 @@ func TestMergePatchIgnoresOtherValues(t *testing.T) {
 	}
 }
 
+func TestMergePatchNilDoc(t *testing.T) {
+	doc := `{ "title": null }`
+	pat := `{ "title": {"foo": "bar"} }`
+
+	res := mergePatch(doc, pat)
+
+	exp := `{ "title": {"foo": "bar"} }`
+
+	if !compareJSON(exp, res) {
+		t.Fatalf("Key was not replaced")
+	}
+}
+
 func TestMergePatchRecursesIntoObjects(t *testing.T) {
 	doc := `{ "person": { "title": "hello", "age": 18 } }`
 	pat := `{ "person": { "title": "goodbye" } }`

--- a/merge_test.go
+++ b/merge_test.go
@@ -184,7 +184,7 @@ func TestMergePatchFailRFCCases(t *testing.T) {
 
 }
 
-func TestMergeReplaceKey(t *testing.T) {
+func TestCreateMergePatchReplaceKey(t *testing.T) {
 	doc := `{ "title": "hello", "nested": {"one": 1, "two": 2} }`
 	pat := `{ "title": "goodbye", "nested": {"one": 2, "two": 2}  }`
 
@@ -201,7 +201,7 @@ func TestMergeReplaceKey(t *testing.T) {
 	}
 }
 
-func TestMergeGetArray(t *testing.T) {
+func TestCreateMergePatchGetArray(t *testing.T) {
 	doc := `{ "title": "hello", "array": ["one", "two"], "notmatch": [1, 2, 3] }`
 	pat := `{ "title": "hello", "array": ["one", "two", "three"], "notmatch": [1, 2, 3]  }`
 
@@ -218,7 +218,7 @@ func TestMergeGetArray(t *testing.T) {
 	}
 }
 
-func TestMergeGetObjArray(t *testing.T) {
+func TestCreateMergePatchGetObjArray(t *testing.T) {
 	doc := `{ "title": "hello", "array": [{"banana": true}, {"evil": false}], "notmatch": [{"one":1}, {"two":2}, {"three":3}] }`
 	pat := `{ "title": "hello", "array": [{"banana": false}, {"evil": true}], "notmatch": [{"one":1}, {"two":2}, {"three":3}] }`
 
@@ -235,7 +235,7 @@ func TestMergeGetObjArray(t *testing.T) {
 	}
 }
 
-func TestMergeDeleteKey(t *testing.T) {
+func TestCreateMergePatchDeleteKey(t *testing.T) {
 	doc := `{ "title": "hello", "nested": {"one": 1, "two": 2} }`
 	pat := `{ "title": "hello", "nested": {"one": 1}  }`
 
@@ -253,7 +253,7 @@ func TestMergeDeleteKey(t *testing.T) {
 	}
 }
 
-func TestMergeEmptyArray(t *testing.T) {
+func TestCreateMergePatchEmptyArray(t *testing.T) {
 	doc := `{ "array": null }`
 	pat := `{ "array": [] }`
 
@@ -288,7 +288,7 @@ func TestCreateMergePatchNil(t *testing.T) {
 	}
 }
 
-func TestMergeObjArray(t *testing.T) {
+func TestCreateMergePatchObjArray(t *testing.T) {
 	doc := `{ "array": [ {"a": {"b": 2}}, {"a": {"b": 3}} ]}`
 	exp := `{}`
 
@@ -304,7 +304,40 @@ func TestMergeObjArray(t *testing.T) {
 	}
 }
 
-func TestMergeComplexMatch(t *testing.T) {
+func TestCreateMergePatchSameOuterArray(t *testing.T) {
+	doc := `[{"foo": "bar"}]`
+	pat := doc
+	exp := `[{}]`
+
+	res, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if exp != string(res) {
+		t.Fatalf("Outer array was not unmodified")
+	}
+}
+
+func TestCreateMergePatchNoDifferences(t *testing.T) {
+	doc := `{ "title": "hello", "nested": {"one": 1, "two": 2} }`
+	pat := doc
+
+	exp := `{}`
+
+	res, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Key was not replaced")
+	}
+}
+
+func TestCreateMergePatchComplexMatch(t *testing.T) {
 	doc := `{"hello": "world","t": true ,"f": false, "n": null,"i": 123,"pi": 3.1416,"a": [1, 2, 3, 4], "nested": {"hello": "world","t": true ,"f": false, "n": null,"i": 123,"pi": 3.1416,"a": [1, 2, 3, 4]} }`
 	empty := `{}`
 	res, err := CreateMergePatch([]byte(doc), []byte(doc))
@@ -319,7 +352,7 @@ func TestMergeComplexMatch(t *testing.T) {
 	}
 }
 
-func TestMergeComplexAddAll(t *testing.T) {
+func TestCreateMergePatchComplexAddAll(t *testing.T) {
 	doc := `{"hello": "world","t": true ,"f": false, "n": null,"i": 123,"pi": 3.1416,"a": [1, 2, 3, 4], "nested": {"hello": "world","t": true ,"f": false, "n": null,"i": 123,"pi": 3.1416,"a": [1, 2, 3, 4]} }`
 	empty := `{}`
 	res, err := CreateMergePatch([]byte(empty), []byte(doc))
@@ -333,7 +366,7 @@ func TestMergeComplexAddAll(t *testing.T) {
 	}
 }
 
-func TestMergeComplexRemoveAll(t *testing.T) {
+func TestCreateMergePatchComplexRemoveAll(t *testing.T) {
 	doc := `{"hello": "world","t": true ,"f": false, "n": null,"i": 123,"pi": 3.1416,"a": [1, 2, 3, 4], "nested": {"hello": "world","t": true ,"f": false, "n": null,"i": 123,"pi": 3.1416,"a": [1, 2, 3, 4]} }`
 	exp := `{"a":null,"f":null,"hello":null,"i":null,"n":null,"nested":null,"pi":null,"t":null}`
 	empty := `{}`
@@ -355,7 +388,7 @@ func TestMergeComplexRemoveAll(t *testing.T) {
 	*/
 }
 
-func TestMergeObjectWithInnerArray(t *testing.T) {
+func TestCreateMergePatchObjectWithInnerArray(t *testing.T) {
 	stateString := `{
 	  "OuterArray": [
 	    {
@@ -379,7 +412,7 @@ func TestMergeObjectWithInnerArray(t *testing.T) {
 	}
 }
 
-func TestMergeReplaceKeyNotEscape(t *testing.T) {
+func TestCreateMergePatchReplaceKeyNotEscape(t *testing.T) {
 	doc := `{ "title": "hello", "nested": {"title/escaped": 1, "two": 2} }`
 	pat := `{ "title": "goodbye", "nested": {"title/escaped": 2, "two": 2}  }`
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -321,7 +321,7 @@ func TestMergeComplexRemoveAll(t *testing.T) {
 	*/
 }
 
-func TestMergeLargeIdentitalObject(t *testing.T) {
+func TestMergeObjectWithInnerArray(t *testing.T) {
 	stateString := `{
 	  "OuterArray": [
 	    {

--- a/merge_test.go
+++ b/merge_test.go
@@ -362,11 +362,11 @@ func TestMergeObjectWithInnerArray(t *testing.T) {
 	}
 }
 
-func TestMergeReplaceKeyRequiringEscape(t *testing.T) {
+func TestMergeReplaceKeyNotEscape(t *testing.T) {
 	doc := `{ "title": "hello", "nested": {"title/escaped": 1, "two": 2} }`
 	pat := `{ "title": "goodbye", "nested": {"title/escaped": 2, "two": 2}  }`
 
-	exp := `{ "title": "goodbye", "nested": {"title~1escaped": 2}  }`
+	exp := `{ "title": "goodbye", "nested": {"title/escaped": 2}  }`
 
 	res, err := CreateMergePatch([]byte(doc), []byte(pat))
 
@@ -380,9 +380,9 @@ func TestMergeReplaceKeyRequiringEscape(t *testing.T) {
 	}
 }
 
-func TestMergePatchReplaceKeyRequiringEscaping(t *testing.T) {
+func TestMergePatchReplaceKeyNotEscaping(t *testing.T) {
 	doc := `{ "obj": { "title/escaped": "hello" } }`
-	pat := `{ "obj": { "title~1escaped": "goodbye" } }`
+	pat := `{ "obj": { "title/escaped": "goodbye" } }`
 	exp := `{ "obj": { "title/escaped": "goodbye" } }`
 
 	res := mergePatch(doc, pat)

--- a/merge_test.go
+++ b/merge_test.go
@@ -315,8 +315,46 @@ func TestCreateMergePatchSameOuterArray(t *testing.T) {
 		t.Errorf("Unexpected error: %s, %s", err, string(res))
 	}
 
-	if exp != string(res) {
+	if !compareJSON(exp, string(res)) {
 		t.Fatalf("Outer array was not unmodified")
+	}
+}
+
+func TestCreateMergePatchModifiedOuterArray(t *testing.T) {
+	doc := `[{"name": "John"}, {"name": "Will"}]`
+	pat := `[{"name": "Jane"}, {"name": "Will"}]`
+	exp := `[{"name": "Jane"}, {}]`
+
+	res, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Fatalf("Expected %s but received %s", exp, res)
+	}
+}
+
+func TestCreateMergePatchMismatchedOuterArray(t *testing.T) {
+	doc := `[{"name": "John"}, {"name": "Will"}]`
+	pat := `[{"name": "Jane"}]`
+
+	_, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err == nil {
+		t.Errorf("Expected error due to array length differences but received none")
+	}
+}
+
+func TestCreateMergePatchMismatchedOuterTypes(t *testing.T) {
+	doc := `[{"name": "John"}]`
+	pat := `{"name": "Jane"}`
+
+	_, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err == nil {
+		t.Errorf("Expected error due to mismatched types but received none")
 	}
 }
 

--- a/merge_test.go
+++ b/merge_test.go
@@ -361,3 +361,33 @@ func TestMergeObjectWithInnerArray(t *testing.T) {
 		t.Fatalf("Patch should have been {} but was: %v", string(patch))
 	}
 }
+
+func TestMergeReplaceKeyRequiringEscape(t *testing.T) {
+	doc := `{ "title": "hello", "nested": {"title/escaped": 1, "two": 2} }`
+	pat := `{ "title": "goodbye", "nested": {"title/escaped": 2, "two": 2}  }`
+
+	exp := `{ "title": "goodbye", "nested": {"title~1escaped": 2}  }`
+
+	res, err := CreateMergePatch([]byte(doc), []byte(pat))
+
+	if err != nil {
+		t.Errorf("Unexpected error: %s, %s", err, string(res))
+	}
+
+	if !compareJSON(exp, string(res)) {
+		t.Log(string(res))
+		t.Fatalf("Key was not replaced")
+	}
+}
+
+func TestMergePatchReplaceKeyRequiringEscaping(t *testing.T) {
+	doc := `{ "obj": { "title/escaped": "hello" } }`
+	pat := `{ "obj": { "title~1escaped": "goodbye" } }`
+	exp := `{ "obj": { "title/escaped": "goodbye" } }`
+
+	res := mergePatch(doc, pat)
+
+	if !compareJSON(exp, res) {
+		t.Fatalf("Key was not replaced")
+	}
+}

--- a/merge_test.go
+++ b/merge_test.go
@@ -184,6 +184,49 @@ func TestMergePatchFailRFCCases(t *testing.T) {
 
 }
 
+func TestResembleJSONArray(t *testing.T) {
+	testCases := []struct {
+		input    []byte
+		expected bool
+	}{
+		// Failure cases
+		{input: []byte(``), expected: false},
+		{input: []byte(`not an array`), expected: false},
+		{input: []byte(`{"foo": "bar"}`), expected: false},
+		{input: []byte(`{"fizz": ["buzz"]}`), expected: false},
+		{input: []byte(`[bad suffix`), expected: false},
+		{input: []byte(`bad prefix]`), expected: false},
+		{input: []byte(`][`), expected: false},
+
+		// Valid cases
+		{input: []byte(`[]`), expected: true},
+		{input: []byte(`["foo", "bar"]`), expected: true},
+		{input: []byte(`[["foo", "bar"]]`), expected: true},
+		{input: []byte(`[not valid syntax]`), expected: true},
+
+		// Valid cases with whitespace
+		{input: []byte(`      []`), expected: true},
+		{input: []byte(`[]      `), expected: true},
+		{input: []byte(`      []      `), expected: true},
+		{input: []byte(`      [        ]      `), expected: true},
+		{input: []byte("\t[]"), expected: true},
+		{input: []byte("[]\n"), expected: true},
+		{input: []byte("\n\t\r[]"), expected: true},
+	}
+
+	for _, test := range testCases {
+		result := resemblesJSONArray(test.input)
+		if result != test.expected {
+			t.Errorf(
+				`expected "%t" but received "%t" for case: "%s"`,
+				test.expected,
+				result,
+				string(test.input),
+			)
+		}
+	}
+}
+
 func TestCreateMergePatchReplaceKey(t *testing.T) {
 	doc := `{ "title": "hello", "nested": {"one": 1, "two": 2} }`
 	pat := `{ "title": "goodbye", "nested": {"one": 2, "two": 2}  }`

--- a/merge_test.go
+++ b/merge_test.go
@@ -320,3 +320,27 @@ func TestMergeComplexRemoveAll(t *testing.T) {
 		}
 	*/
 }
+
+func TestMergeLargeIdentitalObject(t *testing.T) {
+	stateString := `{
+	  "OuterArray": [
+	    {
+		  "InnerArray": [
+	        {
+	          "StringAttr": "abc123"
+	        }
+	      ],
+	      "StringAttr": "def456"
+	    }
+	  ]
+	}`
+
+	patch, err := CreateMergePatch([]byte(stateString), []byte(stateString))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(patch) != "{}" {
+		t.Fatalf("Patch should have been {} but was: %v", string(patch))
+	}
+}

--- a/patch.go
+++ b/patch.go
@@ -66,6 +66,10 @@ func (n *lazyNode) intoDoc() (*partialDoc, error) {
 		return &n.doc, nil
 	}
 
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial document")
+	}
+
 	err := json.Unmarshal(*n.raw, &n.doc)
 
 	if err != nil {
@@ -81,6 +85,10 @@ func (n *lazyNode) intoAry() (*partialArray, error) {
 		return &n.ary, nil
 	}
 
+	if n.raw == nil {
+		return nil, fmt.Errorf("Unable to unmarshal nil pointer as partial array")
+	}
+
 	err := json.Unmarshal(*n.raw, &n.ary)
 
 	if err != nil {
@@ -94,6 +102,10 @@ func (n *lazyNode) intoAry() (*partialArray, error) {
 func (n *lazyNode) compact() []byte {
 	buf := &bytes.Buffer{}
 
+	if n.raw == nil {
+		return nil
+	}
+
 	err := json.Compact(buf, *n.raw)
 
 	if err != nil {
@@ -104,6 +116,10 @@ func (n *lazyNode) compact() []byte {
 }
 
 func (n *lazyNode) tryDoc() bool {
+	if n.raw == nil {
+		return false
+	}
+
 	err := json.Unmarshal(*n.raw, &n.doc)
 
 	if err != nil {
@@ -115,6 +131,10 @@ func (n *lazyNode) tryDoc() bool {
 }
 
 func (n *lazyNode) tryAry() bool {
+	if n.raw == nil {
+		return false
+	}
+
 	err := json.Unmarshal(*n.raw, &n.ary)
 
 	if err != nil {

--- a/patch.go
+++ b/patch.go
@@ -397,7 +397,9 @@ func (d *partialArray) add(key string, val *lazyNode) error {
 		}
 		idx = len(ary) - idx
 	}
-
+	if idx < 0 || idx >= len(ary) || idx > len(cur) {
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
+	}
 	copy(ary[0:idx], cur[0:idx])
 	ary[idx] = val
 	copy(ary[idx+1:], cur[idx:])

--- a/patch.go
+++ b/patch.go
@@ -369,6 +369,15 @@ func (d *partialArray) add(key string, val *lazyNode) error {
 
 	cur := *d
 
+	if idx < 0 {
+		idx *= -1
+
+		if idx > len(ary) {
+			return fmt.Errorf("Unable to access invalid index: %d", idx)
+		}
+		idx = len(ary) - idx
+	}
+
 	copy(ary[0:idx], cur[0:idx])
 	ary[idx] = val
 	copy(ary[idx+1:], cur[idx:])

--- a/patch.go
+++ b/patch.go
@@ -475,8 +475,8 @@ func (p Patch) replace(doc *container, op operation) error {
 		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
 	}
 
-	val, ok := con.get(key)
-	if val == nil || ok != nil {
+	_, ok := con.get(key)
+	if ok != nil {
 		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
 	}
 

--- a/patch.go
+++ b/patch.go
@@ -204,10 +204,7 @@ func (n *lazyNode) equal(o *lazyNode) bool {
 }
 
 func (o operation) kind() string {
-	if obj, ok := o["op"]; ok {
-		if obj == nil {
-			return "unknown"
-		}
+	if obj, ok := o["op"]; ok && obj != nil {
 		var op string
 
 		err := json.Unmarshal(*obj, &op)
@@ -223,7 +220,7 @@ func (o operation) kind() string {
 }
 
 func (o operation) path() string {
-	if obj, ok := o["path"]; ok {
+	if obj, ok := o["path"]; ok && obj != nil  {
 		var op string
 
 		err := json.Unmarshal(*obj, &op)
@@ -239,7 +236,7 @@ func (o operation) path() string {
 }
 
 func (o operation) from() string {
-	if obj, ok := o["from"]; ok {
+	if obj, ok := o["from"]; ok && obj != nil {
 		var op string
 
 		err := json.Unmarshal(*obj, &op)

--- a/patch.go
+++ b/patch.go
@@ -485,7 +485,6 @@ func (p Patch) replace(doc *container, op operation) error {
 
 func (p Patch) move(doc *container, op operation) error {
 	from := op.from()
-	path := op.path()
 
 	con, key := findObject(doc, from)
 
@@ -502,6 +501,8 @@ func (p Patch) move(doc *container, op operation) error {
 	if err != nil {
 		return err
 	}
+
+	path := op.path()
 
 	con, key = findObject(doc, path)
 

--- a/patch.go
+++ b/patch.go
@@ -205,6 +205,9 @@ func (n *lazyNode) equal(o *lazyNode) bool {
 
 func (o operation) kind() string {
 	if obj, ok := o["op"]; ok {
+		if obj == nil {
+			return "unknown"
+		}
 		var op string
 
 		err := json.Unmarshal(*obj, &op)

--- a/patch.go
+++ b/patch.go
@@ -426,13 +426,9 @@ func (d *partialArray) remove(key string) error {
 		return err
 	}
 
-	if idx < 0 || idx >= len(*d) {
-		return fmt.Errorf("Invalid array index %d", idx)
-	}
-
 	cur := *d
 
-	if idx >= len(cur) {
+	if idx < 0 || idx >= len(cur) {
 		return fmt.Errorf("Unable to remove invalid index: %d", idx)
 	}
 

--- a/patch.go
+++ b/patch.go
@@ -366,7 +366,7 @@ func (p Patch) add(doc *partialDoc, op operation) error {
 	con, key := findObject(doc, path)
 
 	if con == nil {
-		return fmt.Errorf("Missing container: %s", path)
+		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: %s", path)
 	}
 
 	con.set(key, op.value())
@@ -379,6 +379,10 @@ func (p Patch) remove(doc *partialDoc, op operation) error {
 
 	con, key := findObject(doc, path)
 
+	if con == nil {
+		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: %s", path)
+	}
+
 	return con.remove(key)
 }
 
@@ -386,6 +390,10 @@ func (p Patch) replace(doc *partialDoc, op operation) error {
 	path := op.path()
 
 	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
+	}
 
 	con.set(key, op.value())
 
@@ -396,6 +404,10 @@ func (p Patch) move(doc *partialDoc, op operation) error {
 	from := op.from()
 
 	con, key := findObject(doc, from)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing from path: %s", from)
+	}
 
 	val, err := con.get(key)
 
@@ -409,6 +421,10 @@ func (p Patch) move(doc *partialDoc, op operation) error {
 
 	con, key = findObject(doc, path)
 
+	if con == nil {
+		return fmt.Errorf("jsonpatch move operation does not apply: doc is missing destination path: %s", path)
+	}
+
 	con.set(key, val)
 
 	return nil
@@ -418,6 +434,10 @@ func (p Patch) test(doc *partialDoc, op operation) error {
 	path := op.path()
 
 	con, key := findObject(doc, path)
+
+	if con == nil {
+		return fmt.Errorf("jsonpatch test operation does not apply: is missing path: %s", path)
+	}
 
 	val, err := con.get(key)
 

--- a/patch.go
+++ b/patch.go
@@ -446,6 +446,11 @@ func (p Patch) replace(doc *container, op operation) error {
 		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing path: %s", path)
 	}
 
+	val, ok := con.get(key)
+	if val == nil || ok != nil {
+		return fmt.Errorf("jsonpatch replace operation does not apply: doc is missing key: %s", path)
+	}
+
 	return con.set(key, op.value())
 }
 

--- a/patch.go
+++ b/patch.go
@@ -14,8 +14,6 @@ const (
 	eAry
 )
 
-const LeftBrace byte = 91 // []byte("[")
-
 type lazyNode struct {
 	raw   *json.RawMessage
 	doc   partialDoc
@@ -495,9 +493,8 @@ func (p Patch) test(doc *container, op operation) error {
 	if val == nil {
 		if op.value().raw == nil {
 			return nil
-		} else {
-			return fmt.Errorf("Testing value %s failed", path)
 		}
+		return fmt.Errorf("Testing value %s failed", path)
 	}
 
 	if val.equal(op.value()) {
@@ -543,7 +540,7 @@ func (p Patch) Apply(doc []byte) ([]byte, error) {
 // document indented.
 func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
 	var pd container
-	if (doc[0] == LeftBrace) {
+	if doc[0] == '[' {
 		pd = &partialArray{}
 	} else {
 		pd = &partialDoc{}

--- a/patch.go
+++ b/patch.go
@@ -264,6 +264,10 @@ func findObject(pd *container, path string) (container, string) {
 
 	split := strings.Split(path, "/")
 
+	if len(split) < 2 {
+		return nil, ""
+	}
+
 	parts := split[1 : len(split)-1]
 
 	key := split[len(split)-1]

--- a/patch.go
+++ b/patch.go
@@ -425,6 +425,14 @@ func (p Patch) test(doc *partialDoc, op operation) error {
 		return err
 	}
 
+	if val == nil {
+		if op.value().raw == nil {
+			return nil
+		} else {
+			return fmt.Errorf("Testing value %s failed", path)
+		}
+	}
+
 	if val.equal(op.value()) {
 		return nil
 	}

--- a/patch.go
+++ b/patch.go
@@ -311,7 +311,7 @@ func (d *partialDoc) get(key string) (*lazyNode, error) {
 func (d *partialDoc) remove(key string) error {
 	_, ok := (*d)[key]
 	if !ok {
-		return fmt.Errorf("Unable to remove nonexistant key: %s", key)
+		return fmt.Errorf("Unable to remove nonexistent key: %s", key)
 	}
 
 	delete(*d, key)

--- a/patch.go
+++ b/patch.go
@@ -617,3 +617,18 @@ func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
 
 	return json.Marshal(pd)
 }
+
+// From http://tools.ietf.org/html/rfc6901#section-4 :
+//
+// Evaluation of each reference token begins by decoding any escaped
+// character sequence.  This is performed by first transforming any
+// occurrence of the sequence '~1' to '/', and then transforming any
+// occurrence of the sequence '~0' to '~'.
+
+var (
+	rfc6901Decoder = strings.NewReplacer("~1", "/", "~0", "~")
+)
+
+func decodePatchKey(k string) string {
+	return rfc6901Decoder.Replace(k)
+}

--- a/patch.go
+++ b/patch.go
@@ -341,7 +341,7 @@ func (d *partialArray) set(key string, val *lazyNode) error {
 	copy(ary, cur)
 
 	if idx >= len(ary) {
-		fmt.Printf("huh?: %#v[%d] %s, %s\n", ary, idx)
+		return fmt.Errorf("Unable to access invalid index: %d", idx)
 	}
 
 	ary[idx] = val

--- a/patch.go
+++ b/patch.go
@@ -469,8 +469,7 @@ func DecodePatch(buf []byte) (Patch, error) {
 // Apply mutates a JSON document according to the patch, and returns the new
 // document.
 func (p Patch) Apply(doc []byte) ([]byte, error) {
-	res, err := p.ApplyIndent(doc, "")
-	return res, err
+	return p.ApplyIndent(doc, "")
 }
 
 // ApplyIndent mutates a JSON document according to the patch, and returns the new

--- a/patch.go
+++ b/patch.go
@@ -14,6 +14,8 @@ const (
 	eAry
 )
 
+const LeftBrace byte = 91 // []byte("[")
+
 type lazyNode struct {
 	raw   *json.RawMessage
 	doc   partialDoc
@@ -257,8 +259,8 @@ Loop:
 	return false
 }
 
-func findObject(pd *partialDoc, path string) (container, string) {
-	doc := container(pd)
+func findObject(pd *container, path string) (container, string) {
+	doc := *pd
 
 	split := strings.Split(path, "/")
 
@@ -409,7 +411,7 @@ func (d *partialArray) remove(key string) error {
 
 }
 
-func (p Patch) add(doc *partialDoc, op operation) error {
+func (p Patch) add(doc *container, op operation) error {
 	path := op.path()
 
 	con, key := findObject(doc, path)
@@ -421,7 +423,7 @@ func (p Patch) add(doc *partialDoc, op operation) error {
 	return con.add(key, op.value())
 }
 
-func (p Patch) remove(doc *partialDoc, op operation) error {
+func (p Patch) remove(doc *container, op operation) error {
 	path := op.path()
 
 	con, key := findObject(doc, path)
@@ -433,7 +435,7 @@ func (p Patch) remove(doc *partialDoc, op operation) error {
 	return con.remove(key)
 }
 
-func (p Patch) replace(doc *partialDoc, op operation) error {
+func (p Patch) replace(doc *container, op operation) error {
 	path := op.path()
 
 	con, key := findObject(doc, path)
@@ -445,7 +447,7 @@ func (p Patch) replace(doc *partialDoc, op operation) error {
 	return con.set(key, op.value())
 }
 
-func (p Patch) move(doc *partialDoc, op operation) error {
+func (p Patch) move(doc *container, op operation) error {
 	from := op.from()
 
 	con, key := findObject(doc, from)
@@ -475,7 +477,7 @@ func (p Patch) move(doc *partialDoc, op operation) error {
 	return con.set(key, val)
 }
 
-func (p Patch) test(doc *partialDoc, op operation) error {
+func (p Patch) test(doc *container, op operation) error {
 	path := op.path()
 
 	con, key := findObject(doc, path)
@@ -540,7 +542,12 @@ func (p Patch) Apply(doc []byte) ([]byte, error) {
 // ApplyIndent mutates a JSON document according to the patch, and returns the new
 // document indented.
 func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
-	pd := &partialDoc{}
+	var pd container
+	if (doc[0] == LeftBrace) {
+		pd = &partialArray{}
+	} else {
+		pd = &partialDoc{}
+	}
 
 	err := json.Unmarshal(doc, pd)
 
@@ -553,15 +560,15 @@ func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
 	for _, op := range p {
 		switch op.kind() {
 		case "add":
-			err = p.add(pd, op)
+			err = p.add(&pd, op)
 		case "remove":
-			err = p.remove(pd, op)
+			err = p.remove(&pd, op)
 		case "replace":
-			err = p.replace(pd, op)
+			err = p.replace(&pd, op)
 		case "move":
-			err = p.move(pd, op)
+			err = p.move(&pd, op)
 		case "test":
-			err = p.test(pd, op)
+			err = p.test(&pd, op)
 		default:
 			err = fmt.Errorf("Unexpected kind: %s", op.kind())
 		}

--- a/patch.go
+++ b/patch.go
@@ -469,6 +469,13 @@ func DecodePatch(buf []byte) (Patch, error) {
 // Apply mutates a JSON document according to the patch, and returns the new
 // document.
 func (p Patch) Apply(doc []byte) ([]byte, error) {
+	res, err := p.ApplyIndent(doc, "")
+	return res, err
+}
+
+// ApplyIndent mutates a JSON document according to the patch, and returns the new
+// document indented.
+func (p Patch) ApplyIndent(doc []byte, indent string) ([]byte, error) {
 	pd := &partialDoc{}
 
 	err := json.Unmarshal(doc, pd)
@@ -498,6 +505,10 @@ func (p Patch) Apply(doc []byte) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if indent != "" {
+		return json.MarshalIndent(pd, "", indent)
 	}
 
 	return json.Marshal(pd)

--- a/patch.go
+++ b/patch.go
@@ -270,7 +270,7 @@ func findObject(pd *partialDoc, path string) (container, string) {
 
 	for _, part := range parts {
 
-		next, ok := doc.get(part)
+		next, ok := doc.get(decodePatchKey(part))
 
 		if next == nil || ok != nil {
 			return nil, ""
@@ -291,7 +291,7 @@ func findObject(pd *partialDoc, path string) (container, string) {
 		}
 	}
 
-	return doc, key
+	return doc, decodePatchKey(key)
 }
 
 func (d *partialDoc) set(key string, val *lazyNode) error {

--- a/patch.go
+++ b/patch.go
@@ -42,7 +42,7 @@ func newLazyNode(raw *json.RawMessage) *lazyNode {
 func (n *lazyNode) MarshalJSON() ([]byte, error) {
 	switch n.which {
 	case eRaw:
-		return *n.raw, nil
+		return json.Marshal(n.raw)
 	case eDoc:
 		return json.Marshal(n.doc)
 	case eAry:

--- a/patch.go
+++ b/patch.go
@@ -450,7 +450,7 @@ func (p Patch) add(doc *container, op operation) error {
 	con, key := findObject(doc, path)
 
 	if con == nil {
-		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: %s", path)
+		return fmt.Errorf("jsonpatch add operation does not apply: doc is missing path: \"%s\"", path)
 	}
 
 	return con.add(key, op.value())
@@ -462,7 +462,7 @@ func (p Patch) remove(doc *container, op operation) error {
 	con, key := findObject(doc, path)
 
 	if con == nil {
-		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: %s", path)
+		return fmt.Errorf("jsonpatch remove operation does not apply: doc is missing path: \"%s\"", path)
 	}
 
 	return con.remove(key)

--- a/patch_test.go
+++ b/patch_test.go
@@ -315,6 +315,24 @@ var TestCases = []TestCase{
 		"",
 	},
 	{
+		`{ "foo": null }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		true,
+		"",
+	},
+	{
+		`{ "foo": {} }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		false,
+		"/foo",
+	},
+	{
+		`{ "foo": [] }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		false,
+		"/foo",
+	},
+	{
 		`{ "baz/foo": "qux" }`,
 		`[ { "op": "test", "path": "/baz~1foo", "value": "qux"} ]`,
 		true,

--- a/patch_test.go
+++ b/patch_test.go
@@ -66,6 +66,13 @@ var Cases = []Case{
 		`{ "foo": [ "bar", "qux", "baz" ] }`,
 	},
 	{
+		`{ "foo": [ "bar", "baz" ] }`,
+		`[
+     { "op": "add", "path": "/foo/-1", "value": "qux" }
+    ]`,
+		`{ "foo": [ "bar", "baz", "qux" ] }`,
+	},
+	{
 		`{ "baz": "qux", "foo": "bar" }`,
 		`[ { "op": "remove", "path": "/baz" } ]`,
 		`{ "foo": "bar" }`,
@@ -211,6 +218,11 @@ var BadCases = []BadCase{
 		`{ "foo": ["bar","baz"]}`,
 		`[ { "op": "replace", "path": "/foo/2", "value": "bum"}]`,
 	},
+	{
+		`{ "foo": ["bar","baz"]}`,
+		`[ { "op": "add", "path": "/foo/-4", "value": "bum"}]`,
+	},
+
 	{
 		`{ "name":{ "foo": "bat", "qux": "bum"}}`,
 		`[ { "op": "replace", "path": "/foo/bar", "value":"baz"}]`,

--- a/patch_test.go
+++ b/patch_test.go
@@ -51,25 +51,25 @@ var Cases = []Case{
 	{
 		`{ "foo": "bar"}`,
 		`[
-         { "op": "add", "path": "/baz", "value": "qux" }
-     ]`,
+        { "op": "add", "path": "/baz", "value": "qux" }
+    ]`,
 		`{
-       "baz": "qux",
-       "foo": "bar"
-     }`,
+      "baz": "qux",
+      "foo": "bar"
+    }`,
 	},
 	{
 		`{ "foo": [ "bar", "baz" ] }`,
 		`[
-     { "op": "add", "path": "/foo/1", "value": "qux" }
-    ]`,
+    { "op": "add", "path": "/foo/1", "value": "qux" }
+   ]`,
 		`{ "foo": [ "bar", "qux", "baz" ] }`,
 	},
 	{
 		`{ "foo": [ "bar", "baz" ] }`,
 		`[
-     { "op": "add", "path": "/foo/-1", "value": "qux" }
-    ]`,
+    { "op": "add", "path": "/foo/-1", "value": "qux" }
+   ]`,
 		`{ "foo": [ "bar", "baz", "qux" ] }`,
 	},
 	{
@@ -88,25 +88,45 @@ var Cases = []Case{
 		`{ "baz": "boo", "foo": "bar" }`,
 	},
 	{
+		`{ "bar": [{"baz": null}]}`,
+		`[ { "op": "replace", "path": "/bar/0/baz", "value": 1 } ]`,
+		`{ "bar": [{"baz": 1}]}`,
+	},
+	{
+		`{ "bar": [{"baz": 1}]}`,
+		`[ { "op": "replace", "path": "/bar/0/baz", "value": null } ]`,
+		`{ "bar": [{"baz": null}]}`,
+	},
+	{
+		`{ "bar": [null]}`,
+		`[ { "op": "replace", "path": "/bar/0", "value": 1 } ]`,
+		`{ "bar": [1]}`,
+	},
+	{
+		`{ "bar": [1]}`,
+		`[ { "op": "replace", "path": "/bar/0", "value": null } ]`,
+		`{ "bar": [null]}`,
+	},
+	{
 		`{
-     "foo": {
-       "bar": "baz",
-       "waldo": "fred"
-     },
-     "qux": {
-       "corge": "grault"
-     }
-   }`,
+    "foo": {
+      "bar": "baz",
+      "waldo": "fred"
+    },
+    "qux": {
+      "corge": "grault"
+    }
+  }`,
 		`[ { "op": "move", "from": "/foo/waldo", "path": "/qux/thud" } ]`,
 		`{
-     "foo": {
-       "bar": "baz"
-     },
-     "qux": {
-       "corge": "grault",
-       "thud": "fred"
-     }
-   }`,
+    "foo": {
+      "bar": "baz"
+    },
+    "qux": {
+      "corge": "grault",
+      "thud": "fred"
+    }
+  }`,
 	},
 	{
 		`{ "foo": [ "all", "grass", "cows", "eat" ] }`,

--- a/patch_test.go
+++ b/patch_test.go
@@ -281,8 +281,16 @@ var BadCases = []BadCase{
 		`[ {"op":null,"path":"","value":null} ]`,
 	},
 	{
-		`{ "foo": ["bar"]}`,
-		`[ {"op":"","path":null} ]`,
+		`{}`,
+		`[ {"op":"add","path":null} ]`,
+	},
+	{
+		`{}`,
+		`[ {"op":null,"path":"/foo"} ]`,
+	},
+	{
+		`{}`,
+		`[ { "op": "copy", "from": null }]`,
 	},
 }
 

--- a/patch_test.go
+++ b/patch_test.go
@@ -276,6 +276,14 @@ var BadCases = []BadCase{
 		`{ "foo": ["bar"]}`,
 		`[ {"op": "add", "path": "/foo/2", "value": "bum"}]`,
 	},
+	{
+		`{ "foo": ["bar"]}`,
+		`[ {"op":null,"path":"","value":null} ]`,
+	},
+	{
+		`{ "foo": ["bar"]}`,
+		`[ {"op":"","path":null} ]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -266,6 +266,12 @@ var TestCases = []TestCase{
 		true,
 		"",
 	},
+	{
+		`{ "baz/foo": "qux" }`,
+		`[ { "op": "test", "path": "/baz~1foo", "value": "qux"} ]`,
+		true,
+		"",
+	},
 }
 
 func TestAllTest(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -163,6 +163,22 @@ var BadCases = []BadCase{
 		`{ "foo": "bar" }`,
 		`[ { "op": "add", "path": "/baz/bat", "value": "qux" } ]`,
 	},
+	{
+		`{ "a": { "b": { "d": 1 } } }`,
+		`[ { "op": "remove", "path": "/a/b/c" } ]`,
+	},
+	{
+		`{ "a": { "b": { "d": 1 } } }`,
+		`[ { "op": "move", "from": "/a/b/c", "path": "/a/b/e" } ]`,
+	},
+	{
+		`{ "a": { "b": [1] } }`,
+		`[ { "op": "remove", "path": "/a/b/1" } ]`,
+	},
+	{
+		`{ "a": { "b": [1] } }`,
+		`[ { "op": "move", "from": "/a/b/1", "path": "/a/b/2" } ]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -207,6 +207,14 @@ var BadCases = []BadCase{
 		`{ "foo": "bar" }`,
 		`[ { "op": "add", "path": "", "value": "qux" } ]`,
 	},
+	{
+		`{ "foo": ["bar","baz"]}`,
+		`[ { "op": "replace", "path": "/foo/2", "value": "bum"}]`,
+	},
+	{
+		`{ "name":{ "foo": "bat", "qux": "bum"}}`,
+		`[ { "op": "replace", "path": "/foo/bar", "value":"baz"}]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -19,12 +19,12 @@ func reformatJSON(j string) string {
 func compareJSON(a, b string) bool {
 	// return Equal([]byte(a), []byte(b))
 
-	var obj_a, obj_b map[string]interface{}
-	json.Unmarshal([]byte(a), &obj_a)
-	json.Unmarshal([]byte(b), &obj_b)
+	var objA, objB map[string]interface{}
+	json.Unmarshal([]byte(a), &objA)
+	json.Unmarshal([]byte(b), &objB)
 
-	// fmt.Printf("Comparing %#v\nagainst %#v\n", obj_a, obj_b)
-	return reflect.DeepEqual(obj_a, obj_b)
+	// fmt.Printf("Comparing %#v\nagainst %#v\n", objA, objB)
+	return reflect.DeepEqual(objA, objB)
 }
 
 func applyPatch(doc, patch string) (string, error) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -141,6 +141,11 @@ var Cases = []Case{
 		`[ { "op": "replace", "path": "/foo/1", "value": "bum"}]`,
 		`{ "foo": ["bar", "bum","baz"]}`,
 	},
+	{
+		`[ {"foo": ["bar","qux","baz"]}]`,
+		`[ { "op": "replace", "path": "/0/foo/0", "value": "bum"}]`,
+		`[ {"foo": ["bum","qux","baz"]}]`,
+	},
 }
 
 type BadCase struct {

--- a/patch_test.go
+++ b/patch_test.go
@@ -146,6 +146,21 @@ var Cases = []Case{
 		`[ { "op": "replace", "path": "/0/foo/0", "value": "bum"}]`,
 		`[ {"foo": ["bum","qux","baz"]}]`,
 	},
+	{
+		`[ {"foo": ["bar","qux","baz"], "bar": ["qux","baz"]}]`,
+		`[ { "op": "copy", "from": "/0/foo/0", "path": "/0/bar/0"}]`,
+		`[ {"foo": ["bar","qux","baz"], "bar": ["bar", "baz"]}]`,
+	},
+	{
+		`[ {"foo": ["bar","qux","baz"], "bar": ["qux","baz"]}]`,
+		`[ { "op": "copy", "from": "/0/foo/0", "path": "/0/bar"}]`,
+		`[ {"foo": ["bar","qux","baz"], "bar": ["bar", "qux", "baz"]}]`,
+	},
+	{
+		`[ { "foo": {"bar": ["qux","baz"]}, "baz": {"qux": "bum"}}]`,
+		`[ { "op": "copy", "from": "/0/foo/bar", "path": "/0/baz/bar"}]`,
+		`[ { "baz": {"bar": ["qux","baz"], "qux":"bum"}, "foo": {"bar": ["qux","baz"]}}]`,
+	},
 }
 
 type BadCase struct {
@@ -239,13 +254,13 @@ type TestCase struct {
 var TestCases = []TestCase{
 	{
 		`{
-			"baz": "qux",
-			"foo": [ "a", 2, "c" ]
-		}`,
+      "baz": "qux",
+      "foo": [ "a", 2, "c" ]
+    }`,
 		`[
-			{ "op": "test", "path": "/baz", "value": "qux" },
-			{ "op": "test", "path": "/foo/1", "value": 2 }
-		]`,
+      { "op": "test", "path": "/baz", "value": "qux" },
+      { "op": "test", "path": "/foo/1", "value": 2 }
+    ]`,
 		true,
 		"",
 	},
@@ -257,13 +272,13 @@ var TestCases = []TestCase{
 	},
 	{
 		`{
-			"baz": "qux",
-			"foo": ["a", 2, "c"]
-		}`,
+      "baz": "qux",
+      "foo": ["a", 2, "c"]
+    }`,
 		`[
-			{ "op": "test", "path": "/baz", "value": "qux" },
-			{ "op": "test", "path": "/foo/1", "value": "c" }
-		]`,
+      { "op": "test", "path": "/baz", "value": "qux" },
+      { "op": "test", "path": "/foo/1", "value": "c" }
+    ]`,
 		false,
 		"/foo/1",
 	},

--- a/patch_test.go
+++ b/patch_test.go
@@ -184,6 +184,14 @@ var BadCases = []BadCase{
 		`{ "a": { "b": [1] } }`,
 		`[ { "op": "move", "from": "/a/b/1", "path": "/a/b/2" } ]`,
 	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "add", "pathz": "/baz", "value": "qux" } ]`,
+	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "add", "path": "", "value": "qux" } ]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -227,6 +227,10 @@ var BadCases = []BadCase{
 		`{ "name":{ "foo": "bat", "qux": "bum"}}`,
 		`[ { "op": "replace", "path": "/foo/bar", "value":"baz"}]`,
 	},
+	{
+		`{ "foo": ["bar"]}`,
+		`[ {"op": "add", "path": "/foo/2", "value": "bum"}]`,
+	},
 }
 
 func TestAllCases(t *testing.T) {

--- a/patch_test.go
+++ b/patch_test.go
@@ -132,6 +132,10 @@ var MutationTestCases = []BadCase{
 		`{ "foo": "bar", "qux": { "baz": 1, "bar": null } }`,
 		`[ { "op": "remove", "path": "/qux/bar" } ]`,
 	},
+	{
+		`{ "foo": "bar", "qux": { "baz": 1, "bar": null } }`,
+		`[ { "op": "replace", "path": "/qux/baz", "value": null } ]`,
+	},
 }
 
 var BadCases = []BadCase{

--- a/patch_test.go
+++ b/patch_test.go
@@ -121,6 +121,11 @@ var Cases = []Case{
 		`[ { "op": "remove", "path": "/qux/bar" } ]`,
 		`{ "foo": "bar", "qux": { "baz": 1 } }`,
 	},
+	{
+		`{ "foo": "bar" }`,
+		`[ { "op": "add", "path": "/baz", "value": null } ]`,
+		`{ "baz": null, "foo": "bar" }`,
+	},
 }
 
 type BadCase struct {

--- a/patch_test.go
+++ b/patch_test.go
@@ -126,6 +126,21 @@ var Cases = []Case{
 		`[ { "op": "add", "path": "/baz", "value": null } ]`,
 		`{ "baz": null, "foo": "bar" }`,
 	},
+	{
+		`{ "foo": ["bar"]}`,
+		`[ { "op": "replace", "path": "/foo/0", "value": "baz"}]`,
+		`{ "foo": ["baz"]}`,
+	},
+	{
+		`{ "foo": ["bar","baz"]}`,
+		`[ { "op": "replace", "path": "/foo/0", "value": "bum"}]`,
+		`{ "foo": ["bum","baz"]}`,
+	},
+	{
+		`{ "foo": ["bar","qux","baz"]}`,
+		`[ { "op": "replace", "path": "/foo/1", "value": "bum"}]`,
+		`{ "foo": ["bar", "bum","baz"]}`,
+	},
 }
 
 type BadCase struct {

--- a/patch_test.go
+++ b/patch_test.go
@@ -214,6 +214,18 @@ var TestCases = []TestCase{
 		false,
 		"/foo/1",
 	},
+	{
+		`{ "baz": "qux" }`,
+		`[ { "op": "test", "path": "/foo", "value": 42 } ]`,
+		false,
+		"/foo",
+	},
+	{
+		`{ "baz": "qux" }`,
+		`[ { "op": "test", "path": "/foo", "value": null } ]`,
+		true,
+		"",
+	},
 }
 
 func TestAllTest(t *testing.T) {


### PR DESCRIPTION
These add more null handling and also support array patches with negative indices.

I think the only real difference between this and upstream is that we check for negative indices on remove.  I don't think we're really doing the right thing either -- if you add a negative index, you should also be able to do a remove but I don't think that is implemented properly upstream.  There's also a case where upstream panics if it can't find a type and we just return an error, but I kind of doubt we hit that during normal operation.